### PR TITLE
Fix regexp initialization

### DIFF
--- a/dist/smart-area.js
+++ b/dist/smart-area.js
@@ -369,7 +369,8 @@ angular.module('smartArea', [])
                     }else if(typeof(element.trigger) === 'object'){
                         // I need to get the index of the last match
                         var searchable = text.substr(0, position),
-                            match, found = false, lastPosition = 0;
+                            match, found = false, lastPosition = -1;
+			element.trigger.lastIndex = 0;
                         while ((match = element.trigger.exec(searchable)) !== null){
                             if(match.index === lastPosition){
                                 break;


### PR DESCRIPTION
I've fix two errors when using dropdown
- lastPosition = -1 is to autocomplete word that not start with a spécific letter (I use /([A-Z][a-z]+)/gi regex (without prefix '@')
- element.trigger.lastIndex = 0; to reinitialize regex object. Otherwise, the dropdown list appears every odd character
