### PR TITLE
Refresh trigger check when irrelevant for dropdown

### DIFF
--- a/dist/smart-area.js
+++ b/dist/smart-area.js
@@ -228,6 +228,7 @@ angular.module('smartArea', [])
                         },0);
                     }else{
                         $scope.dropdown.filterElement.focus();
+			checkTriggers();
                     }
                 }
             };


### PR DESCRIPTION
This solves this bug :
- When you type : @sa => it proposes Samantha
- When you type : @sam => nothing is proposed